### PR TITLE
Remove unused Quartz imports

### DIFF
--- a/screen_reader.py
+++ b/screen_reader.py
@@ -1,8 +1,6 @@
 # Reads the screen and returns relevant data.
 
 import pyautogui
-import Quartz.CoreGraphics as CG
-import Quartz
 from PIL import Image
 from enum import Enum
 from mode import Mode


### PR DESCRIPTION
Remove unused Quartz imports from screen_reader.py that require Mac OS. Now the script should properly run on Windows (unfortunately I don't have a Windows device to test).

Closes #4 